### PR TITLE
refactor: switch JWT prover from Modal to GPU prover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ target/
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+bun.lock

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,7 @@
+# Example config (do not commit secrets)
+PROVER_API_URL=https://prover.zk.email/api/prove
+PROVER_API_KEY=
+PROVER_BLUEPRINT_ID=959b744f-a5dd-489a-9557-bd6abd42e88a
+PROVER_ZKEY_URL=https://storage.googleapis.com/jwt-builder-dev/circuit.zkey.zip
+PROVER_CIRCUIT_CPP_URL=https://storage.googleapis.com/jwt-builder-dev/circuit.wtsn.zip
+PRIVATE_KEY=

--- a/frontend/pages/api/proxyJwtProver.ts
+++ b/frontend/pages/api/proxyJwtProver.ts
@@ -1,6 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import axios from 'axios';
 
+// Prefer environment variables, fallback to provided sample values for local dev
+const PROVER_API_URL = process.env.PROVER_API_URL || 'https://prover.zk.email/api/prove';
+const PROVER_API_KEY = process.env.PROVER_API_KEY;
+const PROVER_BLUEPRINT_ID = process.env.PROVER_BLUEPRINT_ID || '959b744f-a5dd-489a-9557-bd6abd42e88a';
+const PROVER_ZKEY_URL =
+  process.env.PROVER_ZKEY_URL || 'https://storage.googleapis.com/jwt-builder-dev/circuit.zkey.zip';
+const PROVER_CIRCUIT_CPP_URL =
+  process.env.PROVER_CIRCUIT_CPP_URL || 'https://storage.googleapis.com/jwt-builder-dev/circuit.wtsn.zip';
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
@@ -8,35 +17,60 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const response = await axios.post(
-      'https://zkemail--jwt-auth-prover-v0-1-0-flask-app.modal.run/prove/jwt',
-      req.body,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    );
+    // Expecting { input: <circuitInputs> } from the client
+    const { input } = req.body || {};
+    if (!input) {
+      return res.status(400).json({ error: 'Missing required field: input' });
+    }
 
-    res.status(200).json(response.data);
+    if (!PROVER_API_KEY) {
+      return res.status(500).json({
+        error: 'Server is not configured',
+        message: 'Missing PROVER_API_KEY environment variable',
+      });
+    }
+
+    const payload = {
+      blueprintId: PROVER_BLUEPRINT_ID,
+      proofId: '',
+      zkeyDownloadUrl: PROVER_ZKEY_URL,
+      circuitCppDownloadUrl: PROVER_CIRCUIT_CPP_URL,
+      input,
+    };
+
+    const response = await axios.post(PROVER_API_URL, payload, {
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': PROVER_API_KEY,
+      },
+    });
+
+    // Normalize response to the legacy shape expected by the frontend
+    // Map publicOutputs -> pub_signals
+    const normalized = {
+      proof: response.data.proof,
+      pub_signals: response.data.publicOutputs,
+    };
+
+    res.status(200).json(normalized);
   } catch (error) {
-    console.error('Error proxying request to JWT prover:', error);
+    console.error('Error proxying request to prover service:', error);
 
     if (axios.isAxiosError(error)) {
       if (error.response) {
         res.status(error.response.status).json({
-          error: 'Error from JWT prover service',
+          error: 'Error from prover service',
           message: error.response.data,
           status: error.response.status,
         });
       } else if (error.request) {
         res.status(503).json({
-          error: 'No response from JWT prover service',
+          error: 'No response from prover service',
           message: 'The service might be down or unreachable',
         });
       } else {
         res.status(500).json({
-          error: 'Error setting up request to JWT prover',
+          error: 'Error setting up request to prover service',
           message: error.message,
         });
       }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "test": "jest"
   },
   "workspaces": [
-    "packages/*",
-    "scripts"
+    "packages/*"
   ],
   "packageManager": "yarn@3.2.3",
   "engines": {

--- a/packages/circuits/jwt-main.circom
+++ b/packages/circuits/jwt-main.circom
@@ -3,5 +3,3 @@ pragma circom 2.1.6;
 include "./jwt-auth.circom";
 
 component main = JWTAuth(121, 17, 1024, 128, 896, 64, 256);
-
-

--- a/packages/circuits/jwt-main.circom
+++ b/packages/circuits/jwt-main.circom
@@ -1,0 +1,11 @@
+pragma circom 2.1.6;
+
+include "./jwt-auth.circom";
+
+// Concrete entrypoint circuit instantiating the JWTAuth template
+// Parameters chosen to support RSA-2048 with n=121 bits per chunk and k=17 chunks,
+// and reasonable defaults for JWT sizes and claim limits
+// maxMessageLength must be a multiple of 64; Base64 lengths must be multiples of 4
+component main = JWTAuth(121, 17, 1024, 128, 896, 64, 256);
+
+

--- a/packages/circuits/jwt-main.circom
+++ b/packages/circuits/jwt-main.circom
@@ -2,10 +2,6 @@ pragma circom 2.1.6;
 
 include "./jwt-auth.circom";
 
-// Concrete entrypoint circuit instantiating the JWTAuth template
-// Parameters chosen to support RSA-2048 with n=121 bits per chunk and k=17 chunks,
-// and reasonable defaults for JWT sizes and claim limits
-// maxMessageLength must be a multiple of 64; Base64 lengths must be multiples of 4
 component main = JWTAuth(121, 17, 1024, 128, 896, 64, 256);
 
 

--- a/packages/circuits/package.json
+++ b/packages/circuits/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "license": "MIT",
   "scripts": {
-    "build": "mkdir -p build && circom jwt-verifier.circom --r1cs --wasm --sym -l ../../node_modules -c -o ./build",
+    "build": "mkdir -p build && circom jwt-main.circom --r1cs --wasm --sym -l ../../node_modules -c -o ./build",
     "publish": "yarn npm publish --access=public",
     "test": "NODE_OPTIONS=--max_old_space_size=8192 jest --runInBand --detectOpenHandles --forceExit --verbose tests",
     "dev-setup": "NODE_OPTIONS=--max_old_space_size=16384 npx ts-node scripts/dev-setup.ts --output ./build",
@@ -39,6 +39,7 @@
     "/lib",
     "/utils",
     "/scripts",
+    "./jwt-main.circom",
     "./jwt-verifier.circom",
     "./jwt-auth.circom"
   ],

--- a/packages/circuits/package.json
+++ b/packages/circuits/package.json
@@ -24,7 +24,6 @@
     "@types/jest": "^29.5.4",
     "chai": "^4.3.7",
     "circom_tester": "^0.0.19",
-    "circomlib": "^2.0.5",
     "circomlibjs": "^0.1.2",
     "ffjavascript": "^0.2.59",
     "jest": "^29.5.0",

--- a/packages/circuits/scripts/dev-setup.ts
+++ b/packages/circuits/scripts/dev-setup.ts
@@ -39,9 +39,9 @@ if (ZKEY_BEACON == null) {
   ZKEY_BEACON = '0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
 }
 
-let phase1Url = 'https://hermez.s3-eu-west-1.amazonaws.com/powersOfTau28_hez_final_21.ptau';
+let phase1Url = 'https://pse-trusted-setup-ppot.s3.eu-central-1.amazonaws.com/pot28_0080/ppot_0080_21.ptau';
 if (args.body) {
-  phase1Url = 'https://hermez.s3-eu-west-1.amazonaws.com/powersOfTau28_hez_final_23.ptau';
+  phase1Url = 'https://pse-trusted-setup-ppot.s3.eu-central-1.amazonaws.com/pot28_0080/ppot_0080_23.ptau';
 }
 // const buildDir = path.join(__dirname, "../build");
 // const phase1Path = path.join(buildDir, "powersOfTau28_hez_final_21.ptau");
@@ -139,10 +139,7 @@ async function exec() {
     throw new Error(`Circuit file does not exist at path: ${circuitPath}`);
   }
 
-  const phase1Path = path.join(
-    buildDir,
-    args.body ? 'powersOfTau28_hez_final_23.ptau' : 'powersOfTau28_hez_final_21.ptau',
-  );
+  const phase1Path = path.join(buildDir, args.body ? 'ppot_0080_23.ptau' : 'ppot_0080_21.ptau');
 
   await downloadPhase1(phase1Path);
   log('✓ Phase 1:', phase1Path);


### PR DESCRIPTION
### Switch JWT prover from Modal to GPU service

- Updated `frontend/pages/api/proxyJwtProver.ts` to call GPU prover service instead of Modal.
  - Reads config from env: `PROVER_API_URL`, `PROVER_API_KEY`, `PROVER_BLUEPRINT_ID`, `PROVER_ZKEY_URL`, `PROVER_CIRCUIT_CPP_URL`.
  - Expects request body `{ input }`; validates `input`.
  - Sends payload with `blueprintId`, `zkeyDownloadUrl`, `circuitCppDownloadUrl`, and `input`.
  - Adds `x-api-key` header.
  - Normalizes response: `publicOutputs` → `pub_signals`.
  - Updated error messages to reference the prover service.

### Config

- Added `frontend/.env.local.example` with required prover env vars.
- Added `bun.lock` to `.gitignore`.

### Circuits

- Added `packages/circuits/jwt-main.circom`
- Updated `packages/circuits/package.json`:
  - `build` uses `jwt-main.circom`.
  - Removed duplicate `circomlib`.
  - Included `./jwt-main.circom` in files.

### Setup script

- Updated `packages/circuits/scripts/dev-setup.ts` Phase 1 references to PSE PPOT (`ppot_0080_21.ptau` / `ppot_0080_23.ptau`) and adjusted filenames.

### Repo

- Removed `scripts` from root `package.json` workspaces since it was deleted before.

